### PR TITLE
Add minimal API test

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Visit the deployed application: [Cover Flow](https://cover-flow-beta.vercel.app/
 
 ```
 
+## 🧪 Running Tests
+
+Run `npm test` to execute the Node.js tests.
+
 ## 🤝 Contributing
 
 1. Fork the repository

--- a/api/goodreads.js
+++ b/api/goodreads.js
@@ -72,8 +72,7 @@ async function handleSinglePage(req, res, userId, shelf, key, pageNum) {
     });
 
     const feed = parser.parse(xml, { ignoreAttributes: false, attributeNamePrefix: '' });
-    let items = feed?.rss?.channel?.item;
-    if (!Array.isArray(items)) items = items ? [items] : [];
+    const items = feed?.rss?.channel?.item ?? [];
     const title = feed?.rss?.channel?.title ?? '';
 
     const pageData = items.map(raw => ({

--- a/api/goodreads.js
+++ b/api/goodreads.js
@@ -72,7 +72,8 @@ async function handleSinglePage(req, res, userId, shelf, key, pageNum) {
     });
 
     const feed = parser.parse(xml, { ignoreAttributes: false, attributeNamePrefix: '' });
-    const items = feed?.rss?.channel?.item ?? [];
+    let items = feed?.rss?.channel?.item;
+    if (!Array.isArray(items)) items = items ? [items] : [];
     const title = feed?.rss?.channel?.title ?? '';
 
     const pageData = items.map(raw => ({

--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "cover-flow",
   "version": "1.0.0",
   "description": "A beautiful, animated cover flow visualization of your Goodreads library",
-  "keywords": [ "goodreads", "cover-flow", "books", "visualization", "reading", "library" ],
+  "keywords": [
+    "goodreads",
+    "cover-flow",
+    "books",
+    "visualization",
+    "reading",
+    "library"
+  ],
   "private": true,
   "dependencies": {
     "fast-xml-parser": "^5.2.3",
@@ -10,5 +17,9 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
   }
 }

--- a/tests/api-goodreads.test.js
+++ b/tests/api-goodreads.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/goodreads.js';
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    data: null,
+    setHeader(key, value) { this.headers[key] = value; },
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.data = payload; return this; }
+  };
+}
+
+test('invalid userId returns 400', async () => {
+  const req = {
+    method: 'GET',
+    query: { userId: 'abc' }
+  };
+  const res = createMockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.data.error, 'Invalid userId format. Must be numeric.');
+});
+
+test('rejects non-GET methods', async () => {
+  const req = { method: 'POST', query: {} };
+  const res = createMockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 405);
+  assert.equal(res.data.error, 'Method not allowed');
+  assert.equal(res.headers.Allow, 'GET');
+});
+
+test('invalid shelf input returns 400', async () => {
+  const req = {
+    method: 'GET',
+    query: { userId: '123', shelf: '../etc/passwd' }
+  };
+  const res = createMockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.match(res.data.error, /Invalid shelf format/);
+  assert.equal(res.headers['X-Content-Type-Options'], 'nosniff');
+});
+
+test('invalid page parameter returns 400', async () => {
+  const req = {
+    method: 'GET',
+    query: { userId: '123', page: '0' }
+  };
+  const res = createMockRes();
+  await handler(req, res);
+  assert.equal(res.statusCode, 400);
+  assert.match(res.data.error, /Invalid page number/);
+});
+
+test('security headers exist on success', async () => {
+  const mockXml = '<rss><channel><title>Test</title><item></item></channel></rss>';
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({ ok: true, text: async () => mockXml });
+
+  const req = { method: 'GET', query: { userId: '123' } };
+  const res = createMockRes();
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.headers['X-Content-Type-Options'], 'nosniff');
+  assert.equal(res.headers['X-Frame-Options'], 'DENY');
+  assert.equal(res.headers['X-XSS-Protection'], '1; mode=block');
+  assert.equal(res.headers['Referrer-Policy'], 'strict-origin-when-cross-origin');
+
+  global.fetch = originalFetch;
+});

--- a/tests/api-goodreads.test.js
+++ b/tests/api-goodreads.test.js
@@ -57,7 +57,7 @@ test('invalid page parameter returns 400', async () => {
 });
 
 test('security headers exist on success', async () => {
-  const mockXml = '<rss><channel><title>Test</title><item></item></channel></rss>';
+  const mockXml = '<rss><channel><title>Test</title><item><book_id>1</book_id><title>Book</title><author_name>Auth</author_name><book_large_image_url></book_large_image_url></item></channel></rss>';
   const originalFetch = global.fetch;
   global.fetch = async () => ({ ok: true, text: async () => mockXml });
 

--- a/tests/api-goodreads.test.js
+++ b/tests/api-goodreads.test.js
@@ -57,7 +57,10 @@ test('invalid page parameter returns 400', async () => {
 });
 
 test('security headers exist on success', async () => {
-  const mockXml = '<rss><channel><title>Test</title><item><book_id>1</book_id><title>Book</title><author_name>Auth</author_name><book_large_image_url></book_large_image_url></item></channel></rss>';
+  const mockXml = '<rss><channel><title>Test</title>' +
+    '<item><book_id>1</book_id><title>Book</title><author_name>Auth</author_name><book_large_image_url></book_large_image_url></item>' +
+    '<item><book_id>2</book_id><title>Book2</title><author_name>Auth2</author_name><book_large_image_url></book_large_image_url></item>' +
+    '</channel></rss>';
   const originalFetch = global.fetch;
   global.fetch = async () => ({ ok: true, text: async () => mockXml });
 


### PR DESCRIPTION
## Summary
- add `tests/api-goodreads.test.js` using `node:test`
- enable ESM and a `test` script in `package.json`
- note how to run tests in the README
- expand tests to verify invalid methods, invalid shelf and page inputs, and security headers

## Testing
- `npm test` *(fails: fast-xml-parser module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415c25bf748327af24f73a0adc9436