### PR TITLE
Refactor API builder for page param

### DIFF
--- a/public/js/book-data-service.js
+++ b/public/js/book-data-service.js
@@ -37,7 +37,7 @@ export class BookDataService {
       this.onProgress?.('fetch');
 
       while (hasMore && page <= 20) {
-        const apiEndpoint = Config.buildApiEndpoint() + `&page=${page}`;
+        const apiEndpoint = Config.buildApiEndpoint(page);
 
         const response = await fetch(apiEndpoint);
 

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -61,21 +61,27 @@ export const Config = {
 
   /**
    * Build API endpoint URL with current parameters
+   * @param {number} [page] - Optional page number
    * @returns {string} Complete API endpoint URL
    */
-  buildApiEndpoint() {
+  buildApiEndpoint(page) {
     const userId = this.getUserId();
     const shelf = this.getShelf();
     const key = this.getKey();
 
-    let endpoint = `${CONFIG.API_BASE_PATH}?userId=${encodeURIComponent(userId)}&shelf=${encodeURIComponent(shelf)}`;
+    const params = new URLSearchParams({
+      userId,
+      shelf
+    });
 
-    // Add key parameter if it exists
     if (key) {
-      endpoint += `&key=${encodeURIComponent(key)}`;
+      params.set('key', key);
+    }
+    if (page) {
+      params.set('page', page.toString());
     }
 
-    return endpoint;
+    return `${CONFIG.API_BASE_PATH}?${params.toString()}`;
   }
 };
 


### PR DESCRIPTION
## Summary
- enhance `buildApiEndpoint` to accept page argument
- adjust book data service to use new API builder

## Testing
- `npm test` *(fails: Missing script)*
- `npx vercel dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684161d691e88327a6a9586a770254ee