### PR TITLE
Add pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ Visit the deployed application: [Cover Flow](https://cover-flow-beta.vercel.app/
 
 Run `npm test` to execute the Node.js tests.
 
+## 🪝 Git Hooks
+
+Enable the pre-commit hook to automatically run the tests before each commit:
+
+```bash
+git config core.hooksPath githooks
+```
+
 ## 🤝 Contributing
 
 1. Fork the repository

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+npm test
+if [ $? -ne 0 ]; then
+  echo "Tests failed. Commit aborted."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- run tests automatically before each commit via new `githooks/pre-commit`
- document hook usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68418933bdd4832799397f51a2a15eb6